### PR TITLE
Refactor webhook flow

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -1,11 +1,9 @@
 Config = {}
 
-Config.webhook = "" -- The Webhook for Discord-Logs // Of Course :)
 Config.Debug = true -- ATTENTION // Only enable this if no Players are on your Server. Much Things are gonna get Printed which are not for everyone (Like the Webhook :D)
 
 
 -- CELLS // Configurate your Jail Cells
-
 Config.Cells = {
 
     cell1 = {x = -585.9249, y = -615.6224, z = 31.4987, heading = 178.0000},

--- a/config_s.lua
+++ b/config_s.lua
@@ -1,0 +1,1 @@
+Config.webhook = "" -- The Webhook for Discord-Logs // Of Course :)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -9,6 +9,7 @@ server_scripts {
     '@mysql-async/lib/MySQL.lua',
     'functions/sv-functions.lua',
     'server.lua',
+    'config_s.lua',
     'ui/ui-sv.lua'
 }
 
@@ -21,7 +22,7 @@ client_scripts {
 shared_scripts {
     '@ox_lib/init.lua',
     '@ox_target',
-    'Config.lua',
+    'config.lua',
     '@es_extended/imports.lua'
 }
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -22,7 +22,7 @@ client_scripts {
 shared_scripts {
     '@ox_lib/init.lua',
     '@ox_target',
-    'config.lua',
+    'Config.lua',
     '@es_extended/imports.lua'
 }
 


### PR DESCRIPTION
There was a discord webhook exposed in the config.lua. The config.lua, as defined in the fxmanifest is a shared script which means it will be visible to clients as well as to the server. Which also means clients will be able to read the webhook url with certain mod menus and spam the webhook - we don't want that. I created the config_s.lua and added the webhook there so that only the server can read the webhook url.